### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A **Model Context Protocol (MCP)** server for [pub.dev](https://pub.dev), the official package repository for Dart and Flutter.  
 It allows AI assistants to **search**, **analyze**, and **retrieve** detailed information about Dart/Flutter packages.
 
+<a href="https://glama.ai/mcp/servers/@devqxi/pubdev-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devqxi/pubdev-mcp-server/badge" alt="Pub.dev Server MCP server" />
+</a>
+
 ---
 
 ## ✨ Features


### PR DESCRIPTION
This PR adds a badge for the [Pub.dev MCP Server](https://glama.ai/mcp/servers/@devqxi/pubdev-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@devqxi/pubdev-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devqxi/pubdev-mcp-server/badge" alt="Pub.dev Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.