### PR TITLE
fix: update API endpoints to match current pub.dev API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npx @modelcontextprotocol/inspector npx @devqxi/pubdev-mcp-server
 ## 🌐 API Reference
 - `https://pub.dev/api/packages/{package}`
 - `https://pub.dev/api/search`
-- `https://pub.dev/api/packages/{package}/versions`
+- `https://pub.dev/api/packages/{package}/score`
 - `https://pub.dev/packages/{package}/{version}/{doc-type}`
 
 ---
@@ -165,8 +165,15 @@ MIT – See [LICENSE](LICENSE)
 ---
 
 ## 🆕 Changelog
+**v1.0.1**
+- Fix: Use `/api/packages/{name}` instead of removed `/api/packages/{name}/versions` endpoint
+- Fix: Fetch package stats (likes, points, popularity) from `/score` endpoint
+- Fix: Search now fetches package details and scores individually (search API no longer returns inline data)
+- Fix: Correct `versionsBehind` calculation in `check_package_updates`
+- Improvement: `get_package_versions` now returns newest versions first
+
 **v1.0.0**
-- Initial release  
-- All major pub.dev API endpoints supported  
-- Caching & error handling implemented  
-- Full MCP protocol compliance  
+- Initial release
+- All major pub.dev API endpoints supported
+- Caching & error handling implemented
+- Full MCP protocol compliance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "pubdev-mcp-server",
-  "version": "1.0.0",
+  "name": "@devqxi/pubdev-mcp-server",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pubdev-mcp-server",
-      "version": "1.0.0",
+      "name": "@devqxi/pubdev-mcp-server",
+      "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0",
         "node-fetch": "^3.3.2"

--- a/src/pubdev-mcp.ts
+++ b/src/pubdev-mcp.ts
@@ -269,8 +269,17 @@ class PubDevMCPServer {
   }
 
   private async getPackageInfo(packageName: string) {
-    const url = `https://pub.dev/api/packages/${packageName}`;
-    const data = await this.fetchWithCache<any>(url, `package-${packageName}`);
+    // Fetch package info and score in parallel
+    const [data, scoreData] = await Promise.all([
+      this.fetchWithCache<any>(
+        `https://pub.dev/api/packages/${packageName}`,
+        `package-${packageName}`
+      ),
+      this.fetchWithCache<any>(
+        `https://pub.dev/api/packages/${packageName}/score`,
+        `score-${packageName}`
+      )
+    ]);
 
     const packageInfo: PackageInfo = {
       name: data.name,
@@ -290,9 +299,9 @@ class PubDevMCPServer {
           text: JSON.stringify({
             package: packageInfo,
             stats: {
-              likes: data.likes,
-              points: data.points,
-              popularity: data.popularity
+              likes: scoreData.likeCount,
+              points: scoreData.grantedPoints,
+              popularity: scoreData.downloadCount30Days
             },
             publishers: data.publishers,
             uploaders: data.uploaders
@@ -305,10 +314,10 @@ class PubDevMCPServer {
   private async checkPackageUpdates(packageName: string, currentVersion?: string) {
     const url = `https://pub.dev/api/packages/${packageName}`;
     const data = await this.fetchWithCache<any>(url, `package-${packageName}`);
-    
+
     const latestVersion = data.latest.version;
     const latestPublished = data.latest.published;
-    
+
     let updateStatus = {
       packageName,
       currentVersion: currentVersion || 'unknown',
@@ -320,16 +329,13 @@ class PubDevMCPServer {
 
     if (currentVersion) {
       updateStatus.updateAvailable = this.compareVersions(currentVersion, latestVersion) < 0;
-      
-      // Get version history to count versions behind
-      const versionsUrl = `https://pub.dev/api/packages/${packageName}/versions`;
-      const versionsData = await this.fetchWithCache<any>(versionsUrl, `versions-${packageName}`);
-      
-      const currentIndex = versionsData.versions.findIndex((v: any) => v.version === currentVersion);
-      const latestIndex = versionsData.versions.findIndex((v: any) => v.version === latestVersion);
-      
+
+      // Versions are already included in the main package response
+      const currentIndex = data.versions.findIndex((v: any) => v.version === currentVersion);
+      const latestIndex = data.versions.findIndex((v: any) => v.version === latestVersion);
+
       if (currentIndex > -1 && latestIndex > -1) {
-        updateStatus.versionsBehind = currentIndex - latestIndex;
+        updateStatus.versionsBehind = latestIndex - currentIndex;
       }
     }
 
@@ -344,10 +350,14 @@ class PubDevMCPServer {
   }
 
   private async getPackageVersions(packageName: string, limit: number = 10) {
-    const url = `https://pub.dev/api/packages/${packageName}/versions`;
-    const data = await this.fetchWithCache<any>(url, `versions-${packageName}`);
-    
-    const versions: PackageVersion[] = data.versions
+    // Versions are included in the main package endpoint
+    const url = `https://pub.dev/api/packages/${packageName}`;
+    const data = await this.fetchWithCache<any>(url, `package-${packageName}`);
+
+    // Versions are sorted oldest-first in the API, reverse to show newest first
+    const allVersions = [...data.versions].reverse();
+
+    const versions: PackageVersion[] = allVersions
       .slice(0, limit)
       .map((v: any) => ({
         version: v.version,
@@ -442,8 +452,9 @@ class PubDevMCPServer {
   }
 
   private async comparePackageVersions(packageName: string, fromVersion: string, toVersion: string) {
-    const versionsUrl = `https://pub.dev/api/packages/${packageName}/versions`;
-    const data = await this.fetchWithCache<any>(versionsUrl, `versions-${packageName}`);
+    // Versions are included in the main package endpoint
+    const url = `https://pub.dev/api/packages/${packageName}`;
+    const data = await this.fetchWithCache<any>(url, `package-${packageName}`);
     
     const fromVersionData = data.versions.find((v: any) => v.version === fromVersion);
     const toVersionData = data.versions.find((v: any) => v.version === toVersion);
@@ -496,24 +507,47 @@ class PubDevMCPServer {
       sort: sort,
       page: page.toString()
     });
-    
+
     const url = `https://pub.dev/api/search?${params}`;
     const data = await this.fetchWithCache<any>(url, `search-${query}-${sort}-${page}`);
-    
+
+    // The search API only returns package names, fetch details and score for each
+    const packageDetails = await Promise.all(
+      data.packages.slice(0, 10).map(async (pkg: any) => {
+        try {
+          // Fetch both package info and score in parallel
+          const [packageInfo, scoreInfo] = await Promise.all([
+            this.fetchWithCache<any>(
+              `https://pub.dev/api/packages/${pkg.package}`,
+              `package-${pkg.package}`
+            ),
+            this.fetchWithCache<any>(
+              `https://pub.dev/api/packages/${pkg.package}/score`,
+              `score-${pkg.package}`
+            )
+          ]);
+
+          return {
+            name: packageInfo.name,
+            version: packageInfo.latest.version,
+            description: packageInfo.latest.pubspec?.description,
+            points: scoreInfo.grantedPoints,
+            likes: scoreInfo.likeCount,
+            popularity: scoreInfo.downloadCount30Days,
+            publishedAt: packageInfo.latest.published
+          };
+        } catch (error) {
+          console.error(`Failed to fetch details for ${pkg.package}:`, error);
+          return null;
+        }
+      })
+    );
+
     const results = {
       query,
       sort,
       page,
-      totalResults: data.count,
-      packages: data.packages.map((pkg: any) => ({
-        name: pkg.package,
-        version: pkg.latest.version,
-        description: pkg.latest.pubspec?.description,
-        points: pkg.points,
-        likes: pkg.likes,
-        popularity: pkg.popularity,
-        publishedAt: pkg.latest.published
-      }))
+      packages: packageDetails.filter(p => p !== null)
     };
 
     return {


### PR DESCRIPTION
## Summary
- The `/api/packages/{name}/versions` endpoint has been removed from pub.dev — all version data is now fetched from the main `/api/packages/{name}` endpoint
- Package stats (likes, points, popularity) are now fetched from the `/api/packages/{name}/score` endpoint, as these fields are no longer included in the main package response
- The search API now only returns package names — package details and scores are fetched individually with parallel requests
- Fixed `versionsBehind` calculation in `check_package_updates` (was returning negative values)
- `get_package_versions` now returns newest versions first

## Test plan
- [x] `get_package_info` — returns stats (likes, points, popularity) correctly
- [x] `search_packages` — returns full package details with scores
- [x] `get_package_versions` — returns versions newest-first
- [x] `check_package_updates` — returns correct positive `versionsBehind` count
- [x] `compare_package_versions` — dependency diff works correctly
- [x] `get_documentation_changes` — unchanged, still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)